### PR TITLE
added ga.es.initialized to check status of reindexing process

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,19 @@ for replication on elasticsearch.
 
 The `keyProperty` field in `_source` is mandatory since it is used to get the value for querying neo4j.
 
+#### Monitoring the status of the reindexing process
+
+Depending on your configuration, the module can be in `initialization` mode when starting, processing a complete reindexing
+of the Neo4j graph database content (in accordance with your configuration settings)
+
+You can monitor the status of the `init` mode :
+
+```
+CALL ga.es.initialized() YIELD status RETURN status
+```
+
+Returns `true` or `false`
+
 #### Version of Elasticsearch
 
 This module has been tested with Elasticsearch 2.3.0+.

--- a/src/main/java/com/graphaware/module/es/ElasticSearchModule.java
+++ b/src/main/java/com/graphaware/module/es/ElasticSearchModule.java
@@ -47,6 +47,7 @@ public class ElasticSearchModule extends WriterBasedThirdPartyIntegrationModule 
 
     private final ElasticSearchConfiguration config;
     private boolean reindex = false; //this is checked in a single thread
+    private static boolean isReindexed = false;
 
     /**
      * Create a new module.
@@ -81,6 +82,7 @@ public class ElasticSearchModule extends WriterBasedThirdPartyIntegrationModule 
             reindex(database);
             reindex = false;
         }
+        isReindexed = true;
     }
 
     /**
@@ -90,6 +92,8 @@ public class ElasticSearchModule extends WriterBasedThirdPartyIntegrationModule 
     public void initialize(GraphDatabaseService database) {
         if (shouldReIndex("index")) {
             reindex = true;
+        } else {
+            isReindexed = true;
         }
     }
 
@@ -101,6 +105,10 @@ public class ElasticSearchModule extends WriterBasedThirdPartyIntegrationModule 
         if (shouldReIndex("re-index")) {
             reindex = true;
         }
+    }
+
+    public static boolean isReindexCompleted() {
+        return isReindexed;
     }
 
     private boolean shouldReIndex(String logMessage) {

--- a/src/main/java/com/graphaware/module/es/ElasticSearchModule.java
+++ b/src/main/java/com/graphaware/module/es/ElasticSearchModule.java
@@ -47,7 +47,7 @@ public class ElasticSearchModule extends WriterBasedThirdPartyIntegrationModule 
 
     private final ElasticSearchConfiguration config;
     private boolean reindex = false; //this is checked in a single thread
-    private static boolean isReindexed = false;
+    private boolean isReindexed = false;
 
     /**
      * Create a new module.
@@ -107,7 +107,7 @@ public class ElasticSearchModule extends WriterBasedThirdPartyIntegrationModule 
         }
     }
 
-    public static boolean isReindexCompleted() {
+    public boolean isReindexCompleted() {
         return isReindexed;
     }
 

--- a/src/main/java/com/graphaware/module/es/proc/ElasticSearchProcedure.java
+++ b/src/main/java/com/graphaware/module/es/proc/ElasticSearchProcedure.java
@@ -56,6 +56,7 @@ public class ElasticSearchProcedure {
     private static final String PARAMETER_NAME_QUERY = "query";
     private static final String PARAMETER_NAME_OUTPUT = "node";
     private static final String PARAMETER_NAME_SCORE = "score";
+    private static final String PARAMETER_NAME_STATUS = "status";
     private final GraphDatabaseService database;
     private final String uri;
     private final String port;
@@ -95,6 +96,22 @@ public class ElasticSearchProcedure {
                 return Iterators.asRawIterator(getObjectArray(nodes).iterator());
             }
 
+        };
+    }
+
+    public CallableProcedure.BasicProcedure isReindexCompleted() {
+        return new CallableProcedure.BasicProcedure(procedureSignature(getProcedureName("initialized"))
+                .mode(ProcedureSignature.Mode.READ_ONLY)
+                .out(PARAMETER_NAME_STATUS, Neo4jTypes.NTBoolean).build()) {
+
+            @Override
+            public RawIterator<Object[], ProcedureException> apply(Context ctx, Object[] input) throws ProcedureException {
+                List<StatusResult> results = new ArrayList<>();
+                results.add(new StatusResult(((ElasticSearchModule) getStartedRuntime(database).getModule(ElasticSearchModule.class)).isReindexCompleted()));
+                List<Object[]> collector = results.stream().map((r) -> new Object[]{r.status}).collect(Collectors.toList());
+
+                return Iterators.asRawIterator(collector.iterator());
+            }
         };
     }
 
@@ -244,6 +261,14 @@ public class ElasticSearchProcedure {
 
         public void setNode(Node node) {
             this.node = node;
+        }
+    }
+
+    class StatusResult {
+        public final boolean status;
+
+        public StatusResult(boolean status) {
+            this.status = status;
         }
     }
 }

--- a/src/main/java/com/graphaware/module/es/proc/ElasticSearchProcedures.java
+++ b/src/main/java/com/graphaware/module/es/proc/ElasticSearchProcedures.java
@@ -42,6 +42,7 @@ public class ElasticSearchProcedures {
     public void init() throws ProcedureException, KernelException {
         ElasticSearchProcedure esProcedures = new ElasticSearchProcedure(database);
         procedures.register(esProcedures.query());
+        procedures.register(esProcedures.isReindexCompleted());
     }
     
     

--- a/src/test/java/com/graphaware/module/es/ElasticSearchModuleDeclarativeTest.java
+++ b/src/test/java/com/graphaware/module/es/ElasticSearchModuleDeclarativeTest.java
@@ -31,6 +31,8 @@ import java.io.IOException;
 
 import static com.graphaware.runtime.RuntimeRegistry.getRuntime;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 
 public class ElasticSearchModuleDeclarativeTest extends ElasticSearchModuleIntegrationTest {
@@ -145,6 +147,7 @@ public class ElasticSearchModuleDeclarativeTest extends ElasticSearchModuleInteg
                 .newGraphDatabase();
 
         getRuntime(database).waitUntilStarted();
+        assertTrue(((ElasticSearchModule) getRuntime(database).getModule("ES", ElasticSearchModule.class)).isReindexCompleted());
         configuration = (ElasticSearchConfiguration) getRuntime(database).getModule("ES", ElasticSearchModule.class).getConfiguration();
 
         verifyEventualEsReplication();

--- a/src/test/java/com/graphaware/module/es/proc/ElasticSearchModuleEndToEndProcTest.java
+++ b/src/test/java/com/graphaware/module/es/proc/ElasticSearchModuleEndToEndProcTest.java
@@ -87,6 +87,23 @@ public class ElasticSearchModuleEndToEndProcTest extends GraphAwareIntegrationTe
         }
     }
 
+    @Test
+    public void testIsReindexedProcedure() {
+        boolean resultFound = false;
+        try (Transaction tx = getDatabase().beginTx()) {
+            Result result = getDatabase().execute("CALL ga.es.initialized() YIELD status RETURN status");
+            while (result.hasNext()) {
+                Map<String, Object> record = result.next();
+                System.out.println(record.get("status"));
+                assertTrue((boolean) record.get("status"));
+                resultFound = true;
+            }
+
+            tx.success();
+        }
+        assertTrue(resultFound);
+    }
+
     protected String writeSomeStuffToNeo4j() {
         //tx1
         httpClient.executeCypher(baseNeoUrl(), "CREATE (p:Person {name:'Michal Bachman', age:30})-[:WORKS_FOR {since:2013, role:'MD'}]->(c:Company {name:'GraphAware', est: 2013})");

--- a/src/test/java/com/graphaware/module/es/proc/ElasticSearchModuleEndToEndProcTest.java
+++ b/src/test/java/com/graphaware/module/es/proc/ElasticSearchModuleEndToEndProcTest.java
@@ -94,7 +94,6 @@ public class ElasticSearchModuleEndToEndProcTest extends GraphAwareIntegrationTe
             Result result = getDatabase().execute("CALL ga.es.initialized() YIELD status RETURN status");
             while (result.hasNext()) {
                 Map<String, Object> record = result.next();
-                System.out.println(record.get("status"));
                 assertTrue((boolean) record.get("status"));
                 resultFound = true;
             }


### PR DESCRIPTION
@alenegro81 

In accordance with #9 

`CALL ga.es.initialized YIELD status RETURN status` returns true when the init() process is finished, false otherwise.

Returns true if config specify no-reindex.

cc @davidrapin