### PR TITLE
#15 added a "Mapping" class to enable custom mapping in ElasticSearch

### DIFF
--- a/src/main/java/com/graphaware/module/es/ElasticSearchConfiguration.java
+++ b/src/main/java/com/graphaware/module/es/ElasticSearchConfiguration.java
@@ -32,6 +32,7 @@ public class ElasticSearchConfiguration extends BaseTxDrivenModuleConfiguration<
     private static final int DEFAULT_QUEUE_CAPACITY = 10000;
     private static final String DEFAULT_AUTH_USER = null;
     private static final String DEFAULT_AUTH_PASSWORD = null;
+    private static final String DEFAULT_MAPPING = "default";
 
     private final String uri;
     private final String port;
@@ -42,7 +43,8 @@ public class ElasticSearchConfiguration extends BaseTxDrivenModuleConfiguration<
     private final boolean executeBulk;
     private final String authUser;
     private final String authPassword;
-    
+    private final String mapping;
+
 
     /**
      * Construct a new configuration.
@@ -58,8 +60,9 @@ public class ElasticSearchConfiguration extends BaseTxDrivenModuleConfiguration<
      * @param retryOnError      whether to retry an index update after a failure (<code>true</code>) or throw the update away (<code>false</code>).
      * @param queueCapacity     capacity of the queue holding operations to be written to Elasticsearch. Must be positive.
      * @param executeBulk       whether or not to execute updates against Elasticsearch in bulk. It is recommended to set this to <code>true</code>.*
+     * @param mapping           name of the mapping class to use to convert Neo4j node/relationships to ElasticSearch documents.
      */
-    private ElasticSearchConfiguration(InclusionPolicies inclusionPolicies, long initializeUntil, String uri, String port, String index, String keyProperty, boolean retryOnError, int queueCapacity, boolean executeBulk, String authUser, String authPassword) {
+    private ElasticSearchConfiguration(InclusionPolicies inclusionPolicies, long initializeUntil, String uri, String port, String index, String keyProperty, boolean retryOnError, int queueCapacity, boolean executeBulk, String authUser, String authPassword, String mapping) {
         super(inclusionPolicies, initializeUntil);
         this.uri = uri;
         this.port = port;
@@ -70,6 +73,7 @@ public class ElasticSearchConfiguration extends BaseTxDrivenModuleConfiguration<
         this.executeBulk = executeBulk;
         this.authUser = authUser;
         this.authPassword = authPassword;
+        this.mapping = mapping;
     }
 
     /**
@@ -77,43 +81,47 @@ public class ElasticSearchConfiguration extends BaseTxDrivenModuleConfiguration<
      */
     @Override
     public ElasticSearchConfiguration newInstance(InclusionPolicies inclusionPolicies, long initializeUntil) {
-        return new ElasticSearchConfiguration(inclusionPolicies, initializeUntil, getUri(), getPort(), getIndex(), getKeyProperty(), isRetryOnError(), getQueueCapacity(), isExecuteBulk(), DEFAULT_AUTH_USER, DEFAULT_AUTH_PASSWORD);
+        return new ElasticSearchConfiguration(inclusionPolicies, initializeUntil, getUri(), getPort(), getIndex(), getKeyProperty(), isRetryOnError(), getQueueCapacity(), isExecuteBulk(), DEFAULT_AUTH_USER, DEFAULT_AUTH_PASSWORD, getMapping());
     }
 
     public static ElasticSearchConfiguration defaultConfiguration() {
-        return new ElasticSearchConfiguration(DEFAULT_INCLUSION_POLICIES, NEVER, null, null, DEFAULT_INDEX_NAME, DEFAULT_KEY_PROPERTY, DEFAULT_RETRY_ON_ERROR, DEFAULT_QUEUE_CAPACITY, DEFAULT_EXECUTE_BULK, DEFAULT_AUTH_USER, DEFAULT_AUTH_PASSWORD);
+        return new ElasticSearchConfiguration(DEFAULT_INCLUSION_POLICIES, NEVER, null, null, DEFAULT_INDEX_NAME, DEFAULT_KEY_PROPERTY, DEFAULT_RETRY_ON_ERROR, DEFAULT_QUEUE_CAPACITY, DEFAULT_EXECUTE_BULK, DEFAULT_AUTH_USER, DEFAULT_AUTH_PASSWORD, DEFAULT_MAPPING);
     }
 
     public ElasticSearchConfiguration withUri(String uri) {
-        return new ElasticSearchConfiguration(getInclusionPolicies(), initializeUntil(), uri, getPort(), getIndex(), getKeyProperty(), isRetryOnError(), getQueueCapacity(), isExecuteBulk(), getAuthUser(), getAuthPassword());
+        return new ElasticSearchConfiguration(getInclusionPolicies(), initializeUntil(), uri, getPort(), getIndex(), getKeyProperty(), isRetryOnError(), getQueueCapacity(), isExecuteBulk(), getAuthUser(), getAuthPassword(), getMapping());
     }
 
     public ElasticSearchConfiguration withPort(String port) {
-        return new ElasticSearchConfiguration(getInclusionPolicies(), initializeUntil(), getUri(), port, getIndex(), getKeyProperty(), isRetryOnError(), getQueueCapacity(), isExecuteBulk(), getAuthUser(), getAuthPassword());
+        return new ElasticSearchConfiguration(getInclusionPolicies(), initializeUntil(), getUri(), port, getIndex(), getKeyProperty(), isRetryOnError(), getQueueCapacity(), isExecuteBulk(), getAuthUser(), getAuthPassword(), getMapping());
     }
 
     public ElasticSearchConfiguration withIndexName(String indexName) {
-        return new ElasticSearchConfiguration(getInclusionPolicies(), initializeUntil(), getUri(), getPort(), indexName, getKeyProperty(), isRetryOnError(), getQueueCapacity(), isExecuteBulk(), getAuthUser(), getAuthPassword());
+        return new ElasticSearchConfiguration(getInclusionPolicies(), initializeUntil(), getUri(), getPort(), indexName, getKeyProperty(), isRetryOnError(), getQueueCapacity(), isExecuteBulk(), getAuthUser(), getAuthPassword(), getMapping());
     }
 
     public ElasticSearchConfiguration withKeyProperty(String keyProperty) {
-        return new ElasticSearchConfiguration(getInclusionPolicies(), initializeUntil(), getUri(), getPort(), getIndex(), keyProperty, isRetryOnError(), getQueueCapacity(), isExecuteBulk(), getAuthUser(), getAuthPassword());
+        return new ElasticSearchConfiguration(getInclusionPolicies(), initializeUntil(), getUri(), getPort(), getIndex(), keyProperty, isRetryOnError(), getQueueCapacity(), isExecuteBulk(), getAuthUser(), getAuthPassword(), getMapping());
     }
 
     public ElasticSearchConfiguration withRetryOnError(boolean retryOnError) {
-        return new ElasticSearchConfiguration(getInclusionPolicies(), initializeUntil(), getUri(), getPort(), getIndex(), getKeyProperty(), retryOnError, getQueueCapacity(), isExecuteBulk(), getAuthUser(), getAuthPassword());
+        return new ElasticSearchConfiguration(getInclusionPolicies(), initializeUntil(), getUri(), getPort(), getIndex(), getKeyProperty(), retryOnError, getQueueCapacity(), isExecuteBulk(), getAuthUser(), getAuthPassword(), getMapping());
     }
 
     public ElasticSearchConfiguration withQueueCapacity(int queueCapacity) {
-        return new ElasticSearchConfiguration(getInclusionPolicies(), initializeUntil(), getUri(), getPort(), getIndex(), getKeyProperty(), isRetryOnError(), queueCapacity, isExecuteBulk(), getAuthUser(), getAuthPassword());
+        return new ElasticSearchConfiguration(getInclusionPolicies(), initializeUntil(), getUri(), getPort(), getIndex(), getKeyProperty(), isRetryOnError(), queueCapacity, isExecuteBulk(), getAuthUser(), getAuthPassword(), getMapping());
     }
 
     public ElasticSearchConfiguration withExecuteBulk(boolean executeBulk) {
-        return new ElasticSearchConfiguration(getInclusionPolicies(), initializeUntil(), getUri(), getPort(), getIndex(), getKeyProperty(), isRetryOnError(), getQueueCapacity(), executeBulk, getAuthUser(), getAuthPassword());
+        return new ElasticSearchConfiguration(getInclusionPolicies(), initializeUntil(), getUri(), getPort(), getIndex(), getKeyProperty(), isRetryOnError(), getQueueCapacity(), executeBulk, getAuthUser(), getAuthPassword(), getMapping());
     }
     
     public ElasticSearchConfiguration withAuthCredentials(String authUser, String authPassword) {
-        return new ElasticSearchConfiguration(getInclusionPolicies(), initializeUntil(), getUri(), getPort(), getIndex(), getKeyProperty(), isRetryOnError(), getQueueCapacity(), isExecuteBulk(), authUser, authPassword);
+        return new ElasticSearchConfiguration(getInclusionPolicies(), initializeUntil(), getUri(), getPort(), getIndex(), getKeyProperty(), isRetryOnError(), getQueueCapacity(), isExecuteBulk(), authUser, authPassword, getMapping());
+    }
+
+    public ElasticSearchConfiguration withMapping(String mapping) {
+        return new ElasticSearchConfiguration(getInclusionPolicies(), initializeUntil(), getUri(), getPort(), getIndex(), getKeyProperty(), isRetryOnError(), getQueueCapacity(), isExecuteBulk(), getAuthUser(), getAuthPassword(), mapping);
     }
 
     public String getUri() {
@@ -148,9 +156,9 @@ public class ElasticSearchConfiguration extends BaseTxDrivenModuleConfiguration<
       return authUser;
     }
     
-    public String getAuthPassword() {    
-      return authPassword;
-    }
+    public String getAuthPassword() { return authPassword; }
+
+    public String getMapping() { return mapping; }
     
     /**
      * {@inheritDoc}

--- a/src/main/java/com/graphaware/module/es/ElasticSearchModuleBootstrapper.java
+++ b/src/main/java/com/graphaware/module/es/ElasticSearchModuleBootstrapper.java
@@ -39,6 +39,7 @@ public class ElasticSearchModuleBootstrapper extends BaseRuntimeModuleBootstrapp
     private static final String BULK = "bulk";
     private static final String AUTH_USER = "authUser";
     private static final String AUTH_PASSWORD = "authPassword";
+    private static final String MAPPING = "mapping";
 
     @Override
     protected ElasticSearchConfiguration defaultConfiguration() {
@@ -87,10 +88,15 @@ public class ElasticSearchModuleBootstrapper extends BaseRuntimeModuleBootstrapp
             configuration = configuration.withExecuteBulk(Boolean.valueOf(config.get(BULK)));
             LOG.info("Elasticsearch bulk execution set to {}", configuration.isExecuteBulk());
         }
-        
+
         if (configExists(config, AUTH_USER) && configExists(config, AUTH_PASSWORD)) {
             configuration = configuration.withAuthCredentials(config.get(AUTH_USER), config.get(AUTH_PASSWORD));
             LOG.info("Elasticsearch Auth Credentials bulk execution set to {}", configuration.isExecuteBulk());
+        }
+
+        if (configExists(config, MAPPING)) {
+            configuration = configuration.withMapping(config.get(MAPPING));
+            LOG.info("Elasticsearch mapping set to {}", configuration.getMapping());
         }
 
         return new ElasticSearchModule(moduleId, produceWriter(configuration), configuration);

--- a/src/main/java/com/graphaware/module/es/executor/BaseOperationExecutor.java
+++ b/src/main/java/com/graphaware/module/es/executor/BaseOperationExecutor.java
@@ -14,16 +14,12 @@
 
 package com.graphaware.module.es.executor;
 
-import com.graphaware.common.representation.NodeRepresentation;
 import com.graphaware.writer.thirdparty.WriteOperation;
 import io.searchbox.client.JestClient;
 
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
-import static org.springframework.util.Assert.hasLength;
 import static org.springframework.util.Assert.notNull;
 
 /**
@@ -34,24 +30,16 @@ public abstract class BaseOperationExecutor implements OperationExecutor {
     private List<WriteOperation<?>> allFailed;
 
     private final JestClient client;
-    private final String index;
-    private final String keyProperty;
 
     /**
      * Construct a new executor.
      *
      * @param client      Jest client. Must not be <code>null</code>.
-     * @param index       Elasticsearch index name. Must not be <code>null</code> or empty.
-     * @param keyProperty name of the node property that serves as the key, under which the node will be indexed in Elasticsearch. Must not be <code>null</code> or empty.
      */
-    public BaseOperationExecutor(JestClient client, String index, String keyProperty) {
+    public BaseOperationExecutor(JestClient client) {
         notNull(client);
-        hasLength(index);
-        hasLength(keyProperty);
 
         this.client = client;
-        this.index = index;
-        this.keyProperty = keyProperty;
     }
 
     /**
@@ -68,30 +56,6 @@ public abstract class BaseOperationExecutor implements OperationExecutor {
     @Override
     public List<WriteOperation<?>> flush() {
         return allFailed;
-    }
-
-    /**
-     * Get the key under which the given {@link NodeRepresentation} will be indexed in Elasticsearch.
-     *
-     * @param node to be indexed.
-     * @return key of the node.
-     */
-    protected String getKey(NodeRepresentation node) {
-        return String.valueOf(node.getProperties().get(keyProperty));
-    }
-
-    /**
-     * Convert a {@link NodeRepresentation} to a map of properties.
-     *
-     * @param node to convert.
-     * @return map of properties.
-     */
-    protected Map<String, String> nodeToProps(NodeRepresentation node) {
-        Map<String, String> source = new LinkedHashMap<>();
-        for (String key : node.getProperties().keySet()) {
-            source.put(key, String.valueOf(node.getProperties().get(key)));
-        }
-        return source;
     }
 
     /**
@@ -117,10 +81,4 @@ public abstract class BaseOperationExecutor implements OperationExecutor {
         return client;
     }
 
-    /**
-     * @return name of the Elasticsearch index to use for indexing.
-     */
-    protected String getIndex() {
-        return index;
-    }
 }

--- a/src/main/java/com/graphaware/module/es/executor/BulkOperationExecutorFactory.java
+++ b/src/main/java/com/graphaware/module/es/executor/BulkOperationExecutorFactory.java
@@ -25,7 +25,7 @@ public class BulkOperationExecutorFactory implements OperationExecutorFactory {
      * {@inheritDoc}
      */
     @Override
-    public OperationExecutor newExecutor(JestClient client, String index, String keyProperty) {
-        return new BulkOperationExecutor(client, index, keyProperty);
+    public OperationExecutor newExecutor(JestClient client) {
+        return new BulkOperationExecutor(client);
     }
 }

--- a/src/main/java/com/graphaware/module/es/executor/OperationExecutor.java
+++ b/src/main/java/com/graphaware/module/es/executor/OperationExecutor.java
@@ -14,10 +14,9 @@
 
 package com.graphaware.module.es.executor;
 
-import com.graphaware.writer.thirdparty.NodeCreated;
-import com.graphaware.writer.thirdparty.NodeDeleted;
-import com.graphaware.writer.thirdparty.NodeUpdated;
 import com.graphaware.writer.thirdparty.WriteOperation;
+import io.searchbox.action.BulkableAction;
+import io.searchbox.client.JestResult;
 
 import java.util.List;
 
@@ -32,28 +31,15 @@ public interface OperationExecutor {
     void start();
 
     /**
-     * Tell Elasticsearch a node has been created.
+     * Execute some actions in ElasticsSearch.
      *
-     * @param nodeCreated operation.
+     * @param actions actions to execute on ElasticSearch
+     * @param operation the original Neo4j operation
      */
-    void createNode(NodeCreated nodeCreated);
+    void execute(List<BulkableAction<? extends JestResult>> actions, WriteOperation<?> operation);
 
     /**
-     * Tell Elasticsearch a node has been updated.
-     *
-     * @param nodeUpdated operation.
-     */
-    void updateNode(NodeUpdated nodeUpdated);
-
-    /**
-     * Tell Elasticsearch a node has been deleted.
-     *
-     * @param nodeDeleted operation.
-     */
-    void deleteNode(NodeDeleted nodeDeleted);
-
-    /**
-     * Finish executing operations. Guranteed to be called as the last method.
+     * Finish executing operations. Guaranteed to be called as the last method.
      *
      * @return write operations that have not been successful. Never <code>null</code>.
      */

--- a/src/main/java/com/graphaware/module/es/executor/OperationExecutorFactory.java
+++ b/src/main/java/com/graphaware/module/es/executor/OperationExecutorFactory.java
@@ -25,9 +25,7 @@ public interface OperationExecutorFactory {
      * Produce a new executor.
      *
      * @param client      Jest client. Must not be <code>null</code>.
-     * @param index       Elasticsearch index name. Must not be <code>null</code> or empty.
-     * @param keyProperty name of the node property that serves as the key, under which the node will be indexed in Elasticsearch. Must not be <code>null</code> or empty.
      * @return executor.
      */
-    OperationExecutor newExecutor(JestClient client, String index, String keyProperty);
+    OperationExecutor newExecutor(JestClient client);
 }

--- a/src/main/java/com/graphaware/module/es/executor/RequestPerOperationExecutorFactory.java
+++ b/src/main/java/com/graphaware/module/es/executor/RequestPerOperationExecutorFactory.java
@@ -25,7 +25,7 @@ public class RequestPerOperationExecutorFactory implements OperationExecutorFact
      * {@inheritDoc}
      */
     @Override
-    public OperationExecutor newExecutor(JestClient client, String index, String keyProperty) {
-        return new RequestPerOperationExecutor(client, index, keyProperty);
+    public OperationExecutor newExecutor(JestClient client) {
+        return new RequestPerOperationExecutor(client);
     }
 }

--- a/src/main/java/com/graphaware/module/es/mapping/DefaultMapping.java
+++ b/src/main/java/com/graphaware/module/es/mapping/DefaultMapping.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2013-2016 GraphAware
+ *
+ * This file is part of the GraphAware Framework.
+ *
+ * GraphAware Framework is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.graphaware.module.es.mapping;
+
+import com.graphaware.common.representation.NodeRepresentation;
+import com.graphaware.writer.thirdparty.NodeCreated;
+import com.graphaware.writer.thirdparty.NodeDeleted;
+import com.graphaware.writer.thirdparty.NodeUpdated;
+import io.searchbox.action.BulkableAction;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestResult;
+import io.searchbox.core.Delete;
+import io.searchbox.core.Index;
+import io.searchbox.indices.CreateIndex;
+import io.searchbox.indices.IndicesExists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+/**
+ * This mapping indexes all documents in the same ElasticSearch index.
+ *
+ * The node's neo4j labels are stored are ElasticSearch "type".
+ * If a node has multiple labels, it is stored multiple times, once for each label.
+ *
+ * Relationships are not indexed.
+ */
+public class DefaultMapping extends Mapping {
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultMapping.class);
+
+    public DefaultMapping(String index, String keyProperty) {
+        super(index, keyProperty);
+    }
+
+    @Override
+    public Map<String, String> map(NodeRepresentation node) {
+        Map<String, String> source = new LinkedHashMap<>();
+        for (String key : node.getProperties().keySet()) {
+            source.put(key, String.valueOf(node.getProperties().get(key)));
+        }
+        return source;
+    }
+
+    @Override
+    protected List<BulkableAction<? extends JestResult>> deleteNode(NodeDeleted operation) {
+        NodeRepresentation node = operation.getDetails();
+        String id = getKey(node);
+        List<BulkableAction<? extends JestResult>> actions = new ArrayList<>();
+
+        for (String label : node.getLabels()) {
+            actions.add(new Delete.Builder(id).index(getIndex()).type(label).build());
+        }
+
+        return actions;
+    }
+
+    @Override
+    protected List<BulkableAction<? extends JestResult>> updateNode(NodeUpdated operation) {
+        return createOrUpdateNode(operation.getDetails().getCurrent());
+    }
+
+    @Override
+    protected List<BulkableAction<? extends JestResult>> createNode(NodeCreated operation) {
+        return createOrUpdateNode(operation.getDetails());
+    }
+
+    private List<BulkableAction<? extends JestResult>> createOrUpdateNode(NodeRepresentation node) {
+        String id = getKey(node);
+        Map<String, String> source = map(node);
+        List<BulkableAction<? extends JestResult>> actions = new ArrayList<>();
+
+        for (String label : node.getLabels()) {
+            actions.add(new Index.Builder(source).index(getIndex()).type(label).id(id).build());
+        }
+
+        return actions;
+    }
+
+    @Override
+    public void createIndexAndMapping(JestClient client, String index) throws Exception {
+        if (client.execute(new IndicesExists.Builder(index).build()).isSucceeded()) {
+            LOG.info("Index " + index + " already exists in ElasticSearch.");
+        }
+
+        LOG.info("Index " + index + " does not exist in ElasticSearch, creating...");
+
+        final JestResult execute = client.execute(new CreateIndex.Builder(index).build());
+
+        if (execute.isSucceeded()) {
+            LOG.info("Created ElasticSearch index.");
+        } else {
+            LOG.error("Failed to create ElasticSearch index. Details: " + execute.getErrorMessage());
+        }
+    }
+
+}

--- a/src/main/java/com/graphaware/module/es/mapping/Mapping.java
+++ b/src/main/java/com/graphaware/module/es/mapping/Mapping.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2013-2016 GraphAware
+ *
+ * This file is part of the GraphAware Framework.
+ *
+ * GraphAware Framework is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.graphaware.module.es.mapping;
+
+import com.graphaware.common.representation.NodeRepresentation;
+import com.graphaware.writer.thirdparty.*;
+import io.searchbox.action.BulkableAction;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.util.Assert.hasLength;
+
+public abstract class Mapping {
+    private static final Logger LOG = LoggerFactory.getLogger(Mapping.class);
+
+    private final String keyProperty;
+    private final String index;
+
+    /**
+     * @param index       ElasticSearch index name. Must not be <code>null</code> or empty.
+     * @param keyProperty name of the node property that serves as the key, under which the node will be indexed in Elasticsearch. Must not be <code>null</code> or empty.
+     * @param name        name of the mapping to use to convert Neo4j node/relationships to ElasticSearch documents.
+     * @return mapping instance
+     */
+    public static Mapping getMapping(String index, String keyProperty, String name) {
+        hasLength(index);
+        hasLength(keyProperty);
+
+        if (name.equals("default")) {
+            return new DefaultMapping(index, keyProperty);
+        }
+
+        try {
+            return (Mapping) Mapping.class.getClassLoader()
+                    .loadClass(Mapping.class.getPackage().getName() + "." + name)
+                    .getConstructor(String.class, String.class)
+                    .newInstance(index, keyProperty);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not instantiate Mapping \"" + name + "\"", e);
+        }
+    }
+
+    /**
+     *
+     * @param keyProperty name of the node property that serves as the key, under which the node will be indexed in Elasticsearch. Must not be <code>null</code> or empty.
+     */
+    public Mapping(String index, String keyProperty) {
+        hasLength(keyProperty);
+
+        this.index = index;
+        this.keyProperty = keyProperty;
+    }
+
+    /**
+     * Get the key under which the given {@link NodeRepresentation} will be indexed in Elasticsearch.
+     *
+     * @param node to be indexed.
+     * @return key of the node.
+     */
+    protected final String getKey(NodeRepresentation node) {
+        return String.valueOf(node.getProperties().get(keyProperty));
+    }
+
+    /**
+     * @return name of the Elasticsearch index to use for indexing.
+     */
+    protected String getIndex() {
+        return index;
+    }
+
+    /**
+     * Convert a Neo4j representation to a ElasticSearch representation of a node.
+     *
+     * @param node A Neo4j node
+     * @return a map of fields to store in ElasticSearch
+     */
+    protected abstract Map<String, String> map(NodeRepresentation node);
+
+    /**
+     * Create the ElasticSearch index(es) and initialize the mapping
+     *
+     * @param client The ElasticSearch client to use.
+     * @param index Name/prefix of the ElasticSearch index to create and initialize
+     * @throws Exception
+     */
+    public abstract void createIndexAndMapping(JestClient client, String index) throws Exception;
+
+    public final List<BulkableAction<? extends JestResult>> getActions(WriteOperation operation) {
+        switch (operation.getType()) {
+            case NODE_CREATED:
+                return createNode((NodeCreated) operation);
+
+            case NODE_UPDATED:
+                return updateNode((NodeUpdated) operation);
+
+            case NODE_DELETED:
+                return deleteNode((NodeDeleted) operation);
+
+            default:
+                LOG.warn("Unsupported operation " + operation.getType());
+                return Collections.emptyList();
+        }
+    }
+
+    protected abstract List<BulkableAction<? extends JestResult>> createNode(NodeCreated operation);
+
+    protected abstract List<BulkableAction<? extends JestResult>> updateNode(NodeUpdated operation);
+
+    protected abstract List<BulkableAction<? extends JestResult>> deleteNode(NodeDeleted operation);
+
+}

--- a/src/test/java/com/graphaware/module/es/SometimesFailingElasticSearchWriter.java
+++ b/src/test/java/com/graphaware/module/es/SometimesFailingElasticSearchWriter.java
@@ -23,12 +23,12 @@ public class SometimesFailingElasticSearchWriter extends ElasticSearchWriter {
         super(configuration);
     }
 
-    public SometimesFailingElasticSearchWriter(String uri, String port, String keyProperty, String index, boolean retryOnError, OperationExecutorFactory executorFactory) {
-        super(uri, port, keyProperty, index, retryOnError, executorFactory, null, null);
+    public SometimesFailingElasticSearchWriter(String uri, String port, String keyProperty, String index, boolean retryOnError, String mapping, OperationExecutorFactory executorFactory) {
+        super(uri, port, keyProperty, index, retryOnError, executorFactory, null, null, mapping);
     }
 
-    public SometimesFailingElasticSearchWriter(int queueCapacity, String uri, String port, String keyProperty, String index, boolean retryOnError, OperationExecutorFactory executorFactory) {
-        super(queueCapacity, uri, port, keyProperty, index, retryOnError, executorFactory, null, null);
+    public SometimesFailingElasticSearchWriter(int queueCapacity, String uri, String port, String keyProperty, String index, boolean retryOnError, String mapping, OperationExecutorFactory executorFactory) {
+        super(queueCapacity, uri, port, keyProperty, index, retryOnError, executorFactory, null, null, mapping);
     }
 
     @Override

--- a/src/test/resources/integration/int-test-custom.conf
+++ b/src/test/resources/integration/int-test-custom.conf
@@ -17,6 +17,7 @@ com.graphaware.module.ES.node=hasLabel('Person')
 com.graphaware.module.ES.node.property=key != 'age'
 com.graphaware.module.ES.bulk=true
 com.graphaware.module.ES.initializeUntil=0
+com.graphaware.module.ES.mapping=DefaultMapping
 
 org.neo4j.server.thirdparty_jaxrs_classes=com.graphaware.server=/graphaware
 


### PR DESCRIPTION
#15 The default mapping is identical to current behavior.
The Mapping is responsible for translating a Neo4j operation into a list of ElasticSearch actions.
Executors (Bulk or RequestPerOperation) are only responsible for executing the actions returned by the mapping.

This will allow different Neo4j/ElasticSearch mapping strategies to coexist.
For example:

1. DefaultMapping 
 - one index
 - only index nodes
 - store node label as ES type
 - nodes with multiple labels are stored multiple times (one for each Neo4j-label/ES-type)
2. AllInOneMapping (does not exist yet)
 - one index.
 - store node and relationships.
 - use ES type to store "node" or "relationship".
 - store node-labels/relationship-type in a special (analyzed) `_internal_types` array to enable search by label/type.
 - store node-labels/relationship-type in a special (not_analyzed) `_internal_types.raw` array to allow for strict filtering.

Etc.