### PR TITLE
added property value transformation

### DIFF
--- a/src/main/java/com/graphaware/module/es/mapping/json/DocumentMappingDefaults.java
+++ b/src/main/java/com/graphaware/module/es/mapping/json/DocumentMappingDefaults.java
@@ -23,6 +23,7 @@ public class DocumentMappingDefaults {
 
     private static final boolean DEFAULT_INCLUDE_REMAINING = true;
     private static final List<String> DEFAULT_BLACKLIST = new ArrayList<>();
+    private static final boolean DEFAULT_SKIP_NULL_PROPERTIES = false;
 
     @JsonProperty("key_property")
     private String keyProperty;
@@ -43,7 +44,7 @@ public class DocumentMappingDefaults {
     private List<String> blacklistedRelationshipProperties;
 
     @JsonProperty("exclude_empty_properties")
-    private boolean excludeEmptyProperties;
+    private Boolean excludeEmptyProperties;
 
     public String getKeyProperty() {
         return keyProperty;
@@ -70,6 +71,6 @@ public class DocumentMappingDefaults {
     }
 
     public boolean excludeEmptyProperties() {
-        return excludeEmptyProperties;
+        return null != excludeEmptyProperties ? excludeEmptyProperties : DEFAULT_SKIP_NULL_PROPERTIES;
     }
 }

--- a/src/main/java/com/graphaware/module/es/mapping/json/GraphDocumentMapper.java
+++ b/src/main/java/com/graphaware/module/es/mapping/json/GraphDocumentMapper.java
@@ -110,7 +110,7 @@ public class GraphDocumentMapper {
 
             if (defaults.includeRemainingProperties()) {
                 for (String s : node.getProperties().keySet()) {
-                    if (!defaults.getBlacklistedNodeProperties().contains(s)) {
+                    if (!defaults.getBlacklistedNodeProperties().contains(s) && !source.containsKey(s)) {
                         Object o = node.getProperties().get(s);
                         if (o != null || !defaults.excludeEmptyProperties()) {
                             source.put(s, o);

--- a/src/main/java/com/graphaware/module/es/mapping/json/GraphDocumentMapper.java
+++ b/src/main/java/com/graphaware/module/es/mapping/json/GraphDocumentMapper.java
@@ -95,14 +95,26 @@ public class GraphDocumentMapper {
             if (null != properties) {
                 for (String s : properties.keySet()) {
                     Expression exp = getExpression(s);
-                    source.put(s, exp.getValue(nodeExpression));
+                    Object o;
+                    try {
+                        o = exp.getValue(nodeExpression);
+                    } catch (Exception e) {
+                        LOG.warn(e.getMessage());
+                        o = null;
+                    }
+                    if (null != o || !defaults.excludeEmptyProperties()) {
+                        source.put(s, o);
+                    }
                 }
             }
 
             if (defaults.includeRemainingProperties()) {
                 for (String s : node.getProperties().keySet()) {
                     if (!defaults.getBlacklistedNodeProperties().contains(s)) {
-                        source.put(s, node.getProperties().get(s));
+                        Object o = node.getProperties().get(s);
+                        if (o != null || !defaults.excludeEmptyProperties()) {
+                            source.put(s, o);
+                        }
                     }
                 }
             }

--- a/src/main/java/com/graphaware/module/es/mapping/json/PropertyContainerExpression.java
+++ b/src/main/java/com/graphaware/module/es/mapping/json/PropertyContainerExpression.java
@@ -67,4 +67,43 @@ public abstract class PropertyContainerExpression<TPropertyContainerRepresentati
         return dateFormat.format(date);
     }
 
+    public String asString(String key) {
+        if (hasProperty(key)) {
+            return propertyContainer.getProperties().get(key).toString();
+        }
+
+        return null;
+    }
+
+    public Long asLong(String key) {
+        if (hasProperty(key)) {
+            return Long.valueOf(getProperty(key).toString());
+        }
+
+        return null;
+    }
+
+    public Integer asInt(String key) {
+        if (hasProperty(key)) {
+            return Integer.parseInt(getProperty(key).toString());
+        }
+
+        return null;
+    }
+
+    public Float asFloat(String key) {
+        if (hasProperty(key)) {
+            return Float.valueOf(getProperty(key).toString());
+        }
+
+        return null;
+    }
+
+    public Double asDouble(String key) {
+        if (hasProperty(key)) {
+            return Double.valueOf(getProperty(key).toString());
+        }
+
+        return null;
+    }
 }

--- a/src/test/resources/integration/mapping-transformation.json
+++ b/src/test/resources/integration/mapping-transformation.json
@@ -1,0 +1,18 @@
+{
+  "defaults": {
+    "key_property": "uuid",
+    "nodes_index": "nodes",
+    "relationships_index": "relationships"
+  },
+  "node_mappings": [
+    {
+      "condition": "allNodes()",
+      "type": "locations",
+      "properties": {
+        "timestamp": "asInt('time')",
+        "latitude": "asFloat('lat')",
+        "longitude": "asString('long')"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
@alenegro81 @davidrapin @johnbodley 

Just for information, this PR adds the possibility to do property value transformation in case the neo4j db contains node/relationships properties having a mismatch in their type.

An example json could look the following : 

```json
{
  "defaults": {
    "key_property": "uuid",
    "nodes_index": "nodes",
    "relationships_index": "relationships"
  },
  "node_mappings": [
    {
      "condition": "allNodes()",
      "type": "locations",
      "properties": {
        "timestamp": "asInt('time')",
        "latitude": "asFloat('lat')",
        "longitude": "asString('long')"
      }
    }
  ]
}
```