### PR TITLE
Fixing classpath issue in JsonFileMapping.java for Windows environment.

### DIFF
--- a/src/main/java/com/graphaware/module/es/mapping/JsonFileMapping.java
+++ b/src/main/java/com/graphaware/module/es/mapping/JsonFileMapping.java
@@ -36,6 +36,8 @@ public class JsonFileMapping implements Mapping {
 
     private static final String DEFAULT_KEY_PROPERTY = "uuid";
     private static final String FILE_PATH_KEY = "file";
+    private static final String NEO4j_HOME = "unsupported.dbms.directories.neo4j_home";
+    private static final String NEO4j_CONF_DIR = "conf";
 
     private DocumentMappingRepresentation mappingRepresentation;
 
@@ -47,7 +49,13 @@ public class JsonFileMapping implements Mapping {
             throw new RuntimeException("Configuration is missing the " + FILE_PATH_KEY + "key");
         }
         try {
-            String file = new ClassPathResource(config.get("file")).getFile().getAbsolutePath();
+            ClassPathResource classPathResource = new ClassPathResource(config.get(FILE_PATH_KEY));
+			String file = null; 
+			if(classPathResource.exists()){
+				file = classPathResource.getFile().getAbsolutePath();
+			}else{
+				file = config.get(NEO4j_HOME) + File.separator + NEO4j_CONF_DIR + File.separator + config.get(FILE_PATH_KEY);
+			}
             mappingRepresentation = new ObjectMapper().readValue(new File(file), DocumentMappingRepresentation.class);
         } catch (IOException e) {
             throw new RuntimeException("Unable to read json mapping file", e);


### PR DESCRIPTION
Hi,

I have added a fix for reading the mapping.json from neo4j conf directory. 
The existing code will continue to work if the file is found in class path. If the file is not found in the classpath, then using NEO4J_HOME configuration, conf directory path will be computed and will be used. This fix will work for all the environments (WINDOWS, MAC) as well as all the type of NEO4J distributions (Executables, ZIP). 
Following are the Issue references: 
https://github.com/graphaware/neo4j-to-elasticsearch/issues/60
https://github.com/graphaware/neo4j-to-elasticsearch/issues/43