### PR TITLE
reproduction and fix of bulk loading of empty operations

### DIFF
--- a/src/main/java/com/graphaware/module/es/ElasticSearchModule.java
+++ b/src/main/java/com/graphaware/module/es/ElasticSearchModule.java
@@ -30,6 +30,7 @@ import com.graphaware.tx.executor.batch.IterableInputBatchTransactionExecutor;
 import com.graphaware.tx.executor.input.AllNodes;
 import com.graphaware.tx.executor.input.AllRelationships;
 import com.graphaware.writer.thirdparty.NodeCreated;
+import com.graphaware.writer.thirdparty.RelationshipCreated;
 import com.graphaware.writer.thirdparty.ThirdPartyWriter;
 import com.graphaware.writer.thirdparty.WriteOperation;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -189,7 +190,7 @@ public class ElasticSearchModule extends DefaultThirdPartyIntegrationModule {
                 (db, rel, batchNumber, stepNumber) -> {
 
                     if (shouldReindexRelationship(rel)) {
-
+                        operations.add(new RelationshipCreated<>(new RelationshipExpressions(rel)));
                     }
 
                     if (operations.size() >= reindexBatchSize) {

--- a/src/main/java/com/graphaware/module/es/ElasticSearchModule.java
+++ b/src/main/java/com/graphaware/module/es/ElasticSearchModule.java
@@ -131,7 +131,7 @@ public class ElasticSearchModule extends DefaultThirdPartyIntegrationModule {
         }
     }
 
-    private void reindex(GraphDatabaseService database) {
+    public void reindex(GraphDatabaseService database) {
         final InclusionPolicies policies = getConfiguration().getInclusionPolicies();
 
         if (!(policies.getNodeInclusionPolicy() instanceof IncludeNoNodes)) {
@@ -151,7 +151,7 @@ public class ElasticSearchModule extends DefaultThirdPartyIntegrationModule {
         LOG.info("Finished re-indexing database.");
     }
 
-    private void reindexNodes(GraphDatabaseService database) {
+    public void reindexNodes(GraphDatabaseService database) {
         final Collection<WriteOperation<?>> operations = new HashSet<>();
 
         new IterableInputBatchTransactionExecutor<>(

--- a/src/main/java/com/graphaware/module/es/ElasticSearchWriter.java
+++ b/src/main/java/com/graphaware/module/es/ElasticSearchWriter.java
@@ -24,7 +24,9 @@ import com.graphaware.module.es.search.Searcher;
 import com.graphaware.writer.thirdparty.BaseThirdPartyWriter;
 import com.graphaware.writer.thirdparty.ThirdPartyWriter;
 import com.graphaware.writer.thirdparty.WriteOperation;
+import io.searchbox.action.BulkableAction;
 import io.searchbox.client.JestClient;
+import io.searchbox.client.JestResult;
 import org.neo4j.logging.Log;
 
 import java.util.Collection;
@@ -103,10 +105,17 @@ public class ElasticSearchWriter extends BaseThirdPartyWriter {
 
         executor.start();
 
+        int actionsCount = 0;
         for (Collection<WriteOperation<?>> operationGroup : operationGroups) {
             for (WriteOperation<?> operation : operationGroup) {
-                executor.execute(mapping.getActions(operation), operation);
+                List<BulkableAction<? extends JestResult>> actions = mapping.getActions(operation);
+                executor.execute(actions, operation);
+                actionsCount += actions.size();
             }
+        }
+
+        if (actionsCount == 0) {
+            return;
         }
 
         List<WriteOperation<?>> allFailed = executor.flush();

--- a/src/test/java/com/graphaware/module/es/BulkIndexOnInitializeIntegrationTest.java
+++ b/src/test/java/com/graphaware/module/es/BulkIndexOnInitializeIntegrationTest.java
@@ -1,0 +1,99 @@
+package com.graphaware.module.es;
+
+
+import com.graphaware.common.policy.inclusion.all.IncludeAllRelationships;
+import com.graphaware.integration.es.test.EmbeddedElasticSearchServer;
+import com.graphaware.integration.es.test.JestElasticSearchClient;
+import com.graphaware.module.es.mapping.JsonFileMapping;
+import com.graphaware.module.es.util.ServiceLoader;
+import com.graphaware.module.uuid.UuidConfiguration;
+import com.graphaware.module.uuid.UuidModule;
+import com.graphaware.runtime.GraphAwareRuntime;
+import com.graphaware.runtime.GraphAwareRuntimeFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.*;
+
+public class BulkIndexOnInitializeIntegrationTest extends ElasticSearchModuleIntegrationTest {
+
+    @Before
+    public void setUp() {
+        esServer = new EmbeddedElasticSearchServer();
+        esServer.start();
+        esClient = new JestElasticSearchClient(HOST, PORT);
+
+    }
+
+    @After
+    public void tearDown() {
+        database.shutdown();
+        esServer.stop();
+        esClient.shutdown();
+    }
+
+    @Test
+    public void testBulkInsertsDuringInitializePhaseAreBatchedCorrectly() throws Exception {
+        database = new TestGraphDatabaseFactory().newImpermanentDatabase();
+
+        IntStream.range(0, 10).forEach(i -> {
+            try (Transaction tx = database.beginTx()) {
+                database.execute("UNWIND range(0, 1000) AS i CREATE (n:Person {id: i, firstName: 'node' + i, lastName: 'node' + i})");
+                tx.success();
+            }
+        });
+
+        IntStream.range(0, 5).forEach(i -> {
+            try (Transaction tx = database.beginTx()) {
+                database.execute("UNWIND range(0, 1000) AS i CREATE (n:Entity {id: i, firstName: 'node' + i, lastName: 'node' + i})");
+                tx.success();
+            }
+        });
+
+        GraphAwareRuntime runtime = GraphAwareRuntimeFactory.createRuntime(database);
+        runtime.registerModule(new UuidModule("UUID", UuidConfiguration.defaultConfiguration().withInitializeUntil(System.currentTimeMillis()+100000), database));
+
+        JsonFileMapping mapping = (JsonFileMapping) ServiceLoader.loadMapping("com.graphaware.module.es.mapping.JsonFileMapping");
+        Map<String, String> mappingConfig = new HashMap<>();
+        mappingConfig.put("file", "integration/mapping-basic.json");
+
+        configuration = ElasticSearchConfiguration.defaultConfiguration()
+                .withInitializeUntil(System.currentTimeMillis() + 10000)
+                .withMapping(mapping, mappingConfig)
+                .withExecuteBulk(true)
+                .withReindexBatchSize(1000)
+                .withQueueCapacity(10000)
+                .with(IncludeAllRelationships.getInstance())
+                .withUri(HOST)
+                .withPort(PORT);
+
+        runtime.registerModule(new ElasticSearchModule("ES", new ElasticSearchWriter(configuration), configuration));
+        runtime.start();
+        runtime.waitUntilStarted();
+
+
+        boolean hasUuidSet = false;
+        try (Transaction tx = database.beginTx()) {
+            Result result = database.execute("MATCH (n:Person) RETURN n LIMIT 1");
+            while (result.hasNext()) {
+                Node node = (Node) result.next().get("n");
+                hasUuidSet = node.hasProperty("uuid");
+            }
+            tx.success();
+        }
+
+        assertTrue(hasUuidSet);
+
+        runtime.getModule(ElasticSearchModule.class).reindexNodes(database);
+
+    }
+}


### PR DESCRIPTION
This fixes an issue where when during re-index with Bulk enabled, a full Batch was containing nodes that shouldn't be re-indexed and thus wouldn't produce any actions from the `mapping.getActions()` method, the call to `executor.flush()` would try to make a _bulk request with an empty set of operations which isn't supported by ES (so actually the io.searchbox client doesn't make this check).

Note that due to the fact that we don't throw exceptions and try to backoff, the module was running in loop with the backoff and was never emptying the queue, I added an IT with no assertions but for debugging purposes.

Fixes #40 

@bachmanm Please, when merged, make a last release for 3.1.

NB: I tested in Intellij Debug Mode and with a real 3.1.3 CE (see #40 comments for log output)

cc @omarlarus @johnbodley 