### PR TITLE
Multiple Improvements

### DIFF
--- a/docs/json-mapper.md
+++ b/docs/json-mapper.md
@@ -29,8 +29,8 @@ com.graphaware.module.ES.node=
 com.graphaware.module.ES.relationship=(true)
 com.graphaware.module.ES.bulk=true
 com.graphaware.module.ES.initializeUntil=0
-com.graphaware.module.ES.mapping = com.graphaware.module.es.mapping.JsonFileMapping
-com.graphaware.module.ES.file = mapping.json
+com.graphaware.module.ES.mapping=com.graphaware.module.es.mapping.JsonFileMapping
+com.graphaware.module.ES.file=mapping.json
 ```
 
 The last two lines in the configuration specify the type of mapper to use and the name of the file where
@@ -256,5 +256,44 @@ You can predefine a list of blacklisted node / relationship property keys that s
 With the above configuration, passwords will never be included in the json source of the ES documents neither the
 relationship uuid properties.
 
+### Using Cypher queries for replication logic :
 
+It is possible to trigger a Cypher query execution as logic for returning a value to be set as ES document field,
+for example :
+
+```json
+{
+  "defaults": {
+    "key_property": "uuid",
+    "include_remaining_properties": true,
+    "blacklisted_node_properties": ["password", "uuid"]
+  },
+  "node_mappings": [
+    {
+      "condition": "hasLabel('Document') && hasLabel('ReplicationReady')",
+      "type": "documents",
+      "index": "documents",
+      "properties": {
+        "title": "getProperty('title')",
+        "text": "getProperty('text')",
+        "keywords": "query('MATCH (n) WHERE id(n) = {id} MATCH (n)-[:HAS_ANNOTATED_TEXT]->(at)<-[r:DESCRIBES]-(k) apoc.coll.sortMaps(collect({keyword: k.value, relevance: r.relevance}), \"relevance\")[0..5] AS value')"
+      }
+    }
+  ],
+  "relationship_mappings": []
+}
+```
+
+The above mapping defines that the `keywords` field of the ES document should be filled with the result of the query.
+
+**Note:** The result of the query **MUST** have the `value` identifier and **MUST** return a datatype compatible with Elasticsearch.
+
+### Hot reload of the mapping configuration
+
+During development, it is very useful to be able to test the mapping configuration. You can now reload it after any changes to your `mapping.json` file with the
+following procedure :
+
+```
+CALL ga.es.reloadMapping()
+```
 

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-afterburner</artifactId>
+            <version>2.6.5</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.graphaware.neo4j</groupId>
             <artifactId>uuid</artifactId>
             <version>${parent.version}.16</version>

--- a/src/main/java/com/graphaware/module/es/ElasticSearchModule.java
+++ b/src/main/java/com/graphaware/module/es/ElasticSearchModule.java
@@ -191,6 +191,10 @@ public class ElasticSearchModule extends DefaultThirdPartyIntegrationModule {
         }
     }
 
+    public ElasticSearchWriter getWriter() {
+        return writer;
+    }
+
     private void reindexRelationships(GraphDatabaseService database) {
 
         final Collection<WriteOperation<?>> operations = new HashSet<>();

--- a/src/main/java/com/graphaware/module/es/ElasticSearchModule.java
+++ b/src/main/java/com/graphaware/module/es/ElasticSearchModule.java
@@ -84,7 +84,8 @@ public class ElasticSearchModule extends DefaultThirdPartyIntegrationModule {
     @Override
     public void start(GraphDatabaseService database) {
         super.start(database);
-
+        // Must be after start - else there will be a concurrent modification for the serialization of the mapping class
+        config.getMapping().setDatabase(database);
         // Must be after start - else the ES connection is not initialised.
         if (reindex) {
             reindex(database);

--- a/src/main/java/com/graphaware/module/es/ElasticSearchWriter.java
+++ b/src/main/java/com/graphaware/module/es/ElasticSearchWriter.java
@@ -96,6 +96,10 @@ public class ElasticSearchWriter extends BaseThirdPartyWriter {
         LOG.info("Stopped Elasticsearch Writer.");
     }
 
+    public void reloadMapping() {
+        mapping.reload();
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/src/main/java/com/graphaware/module/es/executor/BulkOperationExecutor.java
+++ b/src/main/java/com/graphaware/module/es/executor/BulkOperationExecutor.java
@@ -73,6 +73,10 @@ public class BulkOperationExecutor extends BaseOperationExecutor {
         addFailed(operation);
     }
 
+    public void reset() {
+        bulkBuilder = new Bulk.Builder();
+    }
+
     private void executeBulk(Bulk.Builder bulkBuilder) {
         Bulk bulkOperation = bulkBuilder.build();
         try {

--- a/src/main/java/com/graphaware/module/es/mapping/BaseMapping.java
+++ b/src/main/java/com/graphaware/module/es/mapping/BaseMapping.java
@@ -25,6 +25,7 @@ import io.searchbox.client.JestResult;
 import io.searchbox.indices.CreateIndex;
 import io.searchbox.indices.IndicesExists;
 import org.neo4j.graphdb.Entity;
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.logging.Log;
@@ -45,6 +46,7 @@ public abstract class BaseMapping implements Mapping {
     protected String keyProperty;
     protected String indexPrefix;
     protected boolean forceStrings;
+    protected GraphDatabaseService database;
 
     public BaseMapping() {
     }
@@ -221,5 +223,14 @@ public abstract class BaseMapping implements Mapping {
     @Override
     public boolean bypassInclusionPolicies() {
         return false;
+    }
+
+    @Override
+    public void setDatabase(GraphDatabaseService database) {
+        this.database = database;
+    }
+
+    protected GraphDatabaseService getDatabase() {
+        return database;
     }
 }

--- a/src/main/java/com/graphaware/module/es/mapping/DefaultMapping.java
+++ b/src/main/java/com/graphaware/module/es/mapping/DefaultMapping.java
@@ -112,4 +112,9 @@ public class DefaultMapping extends BaseMapping implements Mapping {
     public <T extends Entity> String getIndexFor(Class<T> searchedType) {
         return getIndexPrefix() + (searchedType.equals(Node.class) ? "-node" : "-relationship");
     }
+
+    @Override
+    public void reload() {
+
+    }
 }

--- a/src/main/java/com/graphaware/module/es/mapping/JsonFileMapping.java
+++ b/src/main/java/com/graphaware/module/es/mapping/JsonFileMapping.java
@@ -42,9 +42,11 @@ public class JsonFileMapping implements Mapping {
     private DocumentMappingRepresentation mappingRepresentation;
     private GraphDatabaseService database;
     protected String keyProperty;
+    private Map<String, String> config;
 
     @Override
     public void configure(Map<String, String> config) {
+        this.config = config;
         if (!config.containsKey(FILE_PATH_KEY)) {
             throw new RuntimeException("Configuration is missing the " + FILE_PATH_KEY + "key");
         }
@@ -114,6 +116,12 @@ public class JsonFileMapping implements Mapping {
     @Override
     public void setDatabase(GraphDatabaseService database) {
         this.database = database;
+        this.mappingRepresentation.setDatabase(database);
+    }
+
+    @Override
+    public void reload() {
+        configure(config);
         this.mappingRepresentation.setDatabase(database);
     }
 }

--- a/src/main/java/com/graphaware/module/es/mapping/JsonFileMapping.java
+++ b/src/main/java/com/graphaware/module/es/mapping/JsonFileMapping.java
@@ -23,6 +23,7 @@ import io.searchbox.action.BulkableAction;
 import io.searchbox.client.JestClient;
 import io.searchbox.client.JestResult;
 import org.neo4j.graphdb.Entity;
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.logging.Log;
 import org.springframework.core.io.ClassPathResource;
 
@@ -38,9 +39,8 @@ public class JsonFileMapping implements Mapping {
     private static final String FILE_PATH_KEY = "file";
     private static final String NEO4j_HOME = "unsupported.dbms.directories.neo4j_home";
     private static final String NEO4j_CONF_DIR = "conf";
-
     private DocumentMappingRepresentation mappingRepresentation;
-
+    private GraphDatabaseService database;
     protected String keyProperty;
 
     @Override
@@ -109,5 +109,11 @@ public class JsonFileMapping implements Mapping {
     @Override
     public boolean bypassInclusionPolicies() {
         return true;
+    }
+
+    @Override
+    public void setDatabase(GraphDatabaseService database) {
+        this.database = database;
+        this.mappingRepresentation.setDatabase(database);
     }
 }

--- a/src/main/java/com/graphaware/module/es/mapping/Mapping.java
+++ b/src/main/java/com/graphaware/module/es/mapping/Mapping.java
@@ -91,4 +91,6 @@ public interface Mapping {
      * @return boolean
      */
     boolean bypassInclusionPolicies();
+
+    void reload();
 }

--- a/src/main/java/com/graphaware/module/es/mapping/Mapping.java
+++ b/src/main/java/com/graphaware/module/es/mapping/Mapping.java
@@ -25,6 +25,7 @@ import io.searchbox.action.BulkableAction;
 import io.searchbox.client.JestClient;
 import io.searchbox.client.JestResult;
 import org.neo4j.graphdb.Entity;
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.logging.Log;
 
 import java.util.Collections;
@@ -42,6 +43,8 @@ public interface Mapping {
     <T extends Entity> String getIndexFor(Class<T> searchedType);
 
     String getKeyProperty();
+
+    void setDatabase(GraphDatabaseService database);
 
     default List<BulkableAction<? extends JestResult>> getActions(WriteOperation<?> operation) {
         switch (operation.getType()) {

--- a/src/main/java/com/graphaware/module/es/mapping/expression/NodeExpressions.java
+++ b/src/main/java/com/graphaware/module/es/mapping/expression/NodeExpressions.java
@@ -15,7 +15,9 @@
 package com.graphaware.module.es.mapping.expression;
 
 import com.graphaware.common.representation.GraphDetachedNode;
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
 
 public class NodeExpressions extends GraphDetachedNode implements ConvertingEntityExpressions {
 
@@ -35,5 +37,9 @@ public class NodeExpressions extends GraphDetachedNode implements ConvertingEnti
 
     public String getGraphType() {
         return GRAPH_TYPE_NODE;
+    }
+
+    public QueryExpression query(String query) {
+        return new QueryExpression(query);
     }
 }

--- a/src/main/java/com/graphaware/module/es/mapping/expression/QueryExpression.java
+++ b/src/main/java/com/graphaware/module/es/mapping/expression/QueryExpression.java
@@ -1,0 +1,14 @@
+package com.graphaware.module.es.mapping.expression;
+
+public class QueryExpression {
+
+    private String query;
+
+    public QueryExpression(String query) {
+        this.query = query;
+    }
+
+    public String getQuery() {
+        return query;
+    }
+}

--- a/src/main/java/com/graphaware/module/es/mapping/json/DocumentRepresentation.java
+++ b/src/main/java/com/graphaware/module/es/mapping/json/DocumentRepresentation.java
@@ -31,8 +31,6 @@ public class DocumentRepresentation {
     private final String id;
 
     private final Map<String, Object> source;
-    
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     public DocumentRepresentation(String index, String type, String id) {
         this.index = index;
@@ -62,15 +60,5 @@ public class DocumentRepresentation {
 
     public Map<String, Object> getSource() {
         return source;
-    }
-    
-    public String getJson() throws DocumentRepresentationException {
-        try {
-            return objectMapper.writeValueAsString(source);
-        } catch (IOException ex) {
-            LOG.error("Error while creating json from action: " + source, ex);
-            // @// TODO: 24/07/16  Should we really throw the exception here, instead of silently logging and failing 
-            throw new DocumentRepresentationException(source, ex);
-        }
     }
 }

--- a/src/main/java/com/graphaware/module/es/mapping/json/GraphDocumentMapper.java
+++ b/src/main/java/com/graphaware/module/es/mapping/json/GraphDocumentMapper.java
@@ -271,6 +271,7 @@ public class GraphDocumentMapper {
             tx.success();
         } catch (Exception e) {
             LOG.error("Could not execute query " + queryExpression.getQuery() + ". Message is " + e.getMessage());
+            e.printStackTrace();
         }
 
         return r;

--- a/src/main/java/com/graphaware/module/es/mapping/json/GraphDocumentMapper.java
+++ b/src/main/java/com/graphaware/module/es/mapping/json/GraphDocumentMapper.java
@@ -16,11 +16,16 @@ package com.graphaware.module.es.mapping.json;
 import com.graphaware.common.log.LoggerFactory;
 import com.graphaware.common.representation.DetachedEntity;
 import com.graphaware.module.es.mapping.expression.NodeExpressions;
+import com.graphaware.module.es.mapping.expression.QueryExpression;
 import com.graphaware.module.es.mapping.expression.RelationshipExpressions;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.logging.Log;
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.springframework.expression.ParseException;
@@ -39,7 +44,7 @@ public class GraphDocumentMapper {
     
     private SpelExpressionParser expressionParser;
     
-    //Some cache to avoid continous parsing
+    //Some cache to avoid continuous parsing
     private Map<String, Expression> expressions;
     private Expression typeExpression;
     private Map<String, Expression> indexsExpression;
@@ -81,11 +86,11 @@ public class GraphDocumentMapper {
         return false;
     }
 
-    public DocumentRepresentation getDocumentRepresentation(NodeExpressions node, DocumentMappingDefaults defaults) throws DocumentRepresentationException {
-        return getDocumentRepresentation(node, defaults, true);
+    public DocumentRepresentation getDocumentRepresentation(NodeExpressions node, DocumentMappingDefaults defaults, GraphDatabaseService graphDatabaseService) throws DocumentRepresentationException {
+        return getDocumentRepresentation(node, defaults, true, graphDatabaseService);
     }
 
-    public DocumentRepresentation getDocumentRepresentation(NodeExpressions node, DocumentMappingDefaults defaults, boolean buildSource) throws DocumentRepresentationException {
+    public DocumentRepresentation getDocumentRepresentation(NodeExpressions node, DocumentMappingDefaults defaults, boolean buildSource, GraphDatabaseService graphDatabaseService) throws DocumentRepresentationException {
         Map<String, Object> source = new HashMap<>();
         String i = getIndex(node, defaults.getDefaultNodesIndex());
         String id = getKeyProperty(node, defaults.getKeyProperty());
@@ -96,7 +101,12 @@ public class GraphDocumentMapper {
                     Expression exp = getExpression(s);
                     Object o;
                     try {
-                        o = exp.getValue(node);
+                        Object t = exp.getValue(node);
+                        if (t instanceof QueryExpression) {
+                            o = getQueryExpressionResult(node, graphDatabaseService, (QueryExpression) t);
+                        } else {
+                            o = exp.getValue(node);
+                        }
                     } catch (Exception e) {
                         LOG.warn(e.getMessage());
                         o = null;
@@ -245,7 +255,25 @@ public class GraphDocumentMapper {
         } else {
             return null;
         }
-        
-        
     }
+
+    private Object getQueryExpressionResult(NodeExpressions node, GraphDatabaseService database, QueryExpression queryExpression) {
+        Map<String, Object> parameters = Collections.singletonMap("id", node.getId());
+        Object r = null;
+        try (Transaction tx = database.beginTx()) {
+            Result result = database.execute(queryExpression.getQuery(), parameters);
+            if (result.hasNext()) {
+                Map<String, Object> record = result.next();
+                if (record.containsKey("value")) {
+                    r = record.get("value");
+                }
+            }
+            tx.success();
+        } catch (Exception e) {
+            LOG.error("Could not execute query " + queryExpression.getQuery() + ". Message is " + e.getMessage());
+        }
+
+        return r;
+    }
+
 }

--- a/src/main/java/com/graphaware/module/es/proc/ElasticSearchProcedures.java
+++ b/src/main/java/com/graphaware/module/es/proc/ElasticSearchProcedures.java
@@ -18,10 +18,7 @@ package com.graphaware.module.es.proc;
 
 import com.graphaware.common.log.LoggerFactory;
 import com.graphaware.module.es.ElasticSearchModule;
-import com.graphaware.module.es.proc.result.JsonSearchResult;
-import com.graphaware.module.es.proc.result.NodeSearchResult;
-import com.graphaware.module.es.proc.result.RelationshipSearchResult;
-import com.graphaware.module.es.proc.result.StatusResult;
+import com.graphaware.module.es.proc.result.*;
 import com.graphaware.module.es.search.Searcher;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -108,6 +105,12 @@ public class ElasticSearchProcedures {
     @Procedure("ga.es.info")
     public Stream<JsonSearchResult> info() {
         return Stream.of(new JsonSearchResult(getSearcher(database).getEsInfo()));
+    }
+
+    @Procedure("ga.es.reloadMapping")
+    public Stream<SingleResult> reloadMapping() {
+        getStartedRuntime(database).getModule(ElasticSearchModule.class).getWriter().reloadMapping();
+        return Stream.of(SingleResult.success());
     }
 }
 

--- a/src/main/java/com/graphaware/module/es/proc/result/SingleResult.java
+++ b/src/main/java/com/graphaware/module/es/proc/result/SingleResult.java
@@ -1,0 +1,18 @@
+package com.graphaware.module.es.proc.result;
+
+public class SingleResult {
+
+    public Object result;
+
+    public SingleResult(Object result) {
+        this.result = result;
+    }
+
+    public static SingleResult success() {
+        return new SingleResult("SUCCESS");
+    }
+
+    public static SingleResult failure() {
+        return new SingleResult("FAILURE");
+    }
+}

--- a/src/test/java/com/graphaware/module/es/ElasticSearchModuleJsonMappingTest.java
+++ b/src/test/java/com/graphaware/module/es/ElasticSearchModuleJsonMappingTest.java
@@ -72,6 +72,8 @@ public class ElasticSearchModuleJsonMappingTest extends ElasticSearchModuleInteg
         cleanUpData();
         testIndexWithAllNodesAndAllRelsExpression();
         cleanUpData();
+        testBasicJsonMappingReplicationWithQuery();
+        cleanUpData();
     }
 
     //@Test
@@ -711,7 +713,6 @@ public class ElasticSearchModuleJsonMappingTest extends ElasticSearchModuleInteg
         }
     }
 
-    @Test
     public void testBasicJsonMappingReplicationWithQuery() {
         database = new TestGraphDatabaseFactory().newImpermanentDatabase();
 

--- a/src/test/java/com/graphaware/module/es/ElasticSearchModuleJsonMappingTest.java
+++ b/src/test/java/com/graphaware/module/es/ElasticSearchModuleJsonMappingTest.java
@@ -711,6 +711,39 @@ public class ElasticSearchModuleJsonMappingTest extends ElasticSearchModuleInteg
         }
     }
 
+    @Test
+    public void testBasicJsonMappingReplicationWithQuery() {
+        database = new TestGraphDatabaseFactory().newImpermanentDatabase();
+
+        GraphAwareRuntime runtime = GraphAwareRuntimeFactory.createRuntime(database);
+        runtime.registerModule(new UuidModule("UUID", UuidConfiguration.defaultConfiguration().withUuidProperty("uuid").with(IncludeAllRelationships.getInstance()), database));
+
+        JsonFileMapping mapping = (JsonFileMapping) ServiceLoader.loadMapping("com.graphaware.module.es.mapping.JsonFileMapping");
+        Map<String, String> mappingConfig = new HashMap<>();
+        mappingConfig.put("file", "integration/mapping-query.json");
+
+        configuration = ElasticSearchConfiguration.defaultConfiguration()
+                .withMapping(mapping, mappingConfig)
+                .with(IncludeAllRelationships.getInstance())
+                .withUri(HOST)
+                .withPort(PORT);
+
+        runtime.registerModule(new ElasticSearchModule("ES", new ElasticSearchWriter(configuration), configuration));
+        runtime.start();
+        runtime.waitUntilStarted();
+
+        writeSomePersons();
+        System.out.println("Finished writing...");
+        TestUtil.waitFor(2000);
+        verifyEsReplicationForNodeWithLabels("Person", mapping.getMappingRepresentation().getDefaults().getDefaultNodesIndex(), "persons", mapping.getMappingRepresentation().getDefaults().getKeyProperty());
+        try (Transaction tx = database.beginTx()) {
+            database.getAllRelationships().stream().forEach(r -> {
+                new Neo4jElasticVerifier(database, configuration, esClient).verifyEsReplication(r, mapping.getMappingRepresentation().getDefaults().getDefaultRelationshipsIndex(), "workers", mapping.getKeyProperty());
+            });
+            tx.success();
+        }
+    }
+
     protected void verifyEsReplicationForNodeWithLabels(String label, String index, String type, String keyProperty) {
         try (Transaction tx = database.beginTx()) {
             database.findNodes(Label.label(label)).stream().forEach(n -> {

--- a/src/test/java/com/graphaware/module/es/ElasticSearchModuleProgrammaticTest.java
+++ b/src/test/java/com/graphaware/module/es/ElasticSearchModuleProgrammaticTest.java
@@ -91,7 +91,7 @@ public class ElasticSearchModuleProgrammaticTest extends ElasticSearchModuleInte
 
         //Actual test:
         writeSomeStuffToNeo4j();
-        waitFor(1000);
+        waitFor(3000);
         verifyEsReplication();
     }
 

--- a/src/test/resources/integration/mapping-query.json
+++ b/src/test/resources/integration/mapping-query.json
@@ -1,0 +1,25 @@
+{
+  "defaults": {
+    "key_property": "uuid",
+    "nodes_index": "default-index-node",
+    "relationships_index": "default-index-relationship",
+    "include_remaining_properties": true,
+    "blacklisted_node_properties": ["password", "uuid"]
+  },
+  "node_mappings": [
+    {
+      "condition": "hasLabel('Person')",
+      "type": "persons",
+      "properties": {
+        "name": "getProperty('firstName') + ' ' + getProperty('lastName')",
+        "myprop": "query('MATCH (n) WHERE id(n) = {id} RETURN size((n)--()) AS value')"
+      }
+    }
+  ],
+  "relationship_mappings": [
+    {
+      "condition": "isType('WORKS_FOR')",
+      "type": "workers"
+    }
+  ]
+}


### PR DESCRIPTION
## Replicate By Query

This PR allows the ability to define queries that will be executed during the replication phase and the results of them to be set as ES document property.

For example, 

```
"node_mappings": [
    {
      "condition": "hasLabel('Person')",
      "type": "persons",
      "properties": {
        "name": "getProperty('firstName') + ' ' + getProperty('lastName')",
        "myprop": "query('MATCH (n) WHERE id(n) = {id} RETURN size((n)--()) AS value')"
      }
    }
  ],
```
```
{"_index":"default-index-node","_type":"persons","_id":"a6650c70-46e7-11e8-8c39-acde48001122","_version":1,"found":true,"_source":{"firstName":"Michal","lastName":"Bachman","myprop":1,"name":"Michal Bachman","age":30}}
{"_index":"default-index-node","_type":"persons","_id":"a69a2630-46e7-11e8-8c39-acde48001122","_version":1,"found":true,"_source":{"firstName":"Adam","lastName":"George","myprop":1,"name":"Adam George"}}
{"_index":"default-index-node","_type":"persons","_id":"a6cb2140-46e7-11e8-8c39-acde48001122","_version":1,"found":true,"_source":{"firstName":"Daniela","lastName":"Daniela","myprop":1,"name":"Daniela Daniela"}}
```
--

## Hot mapping file reload

No need to restart Neo4j anymore to see the changes to your `mapping.json` file applied.

Do your changes, save the file and run the following : 

```
CALL ga.es.reloadMapping()
```


## Performance improvements

The fact that the ObjectMapper was instantiated on the DocumentRepresentation class was causing a serious performance issue. The ObjectMapper has been moved in order to be re-used and we're also making now usage of the Jackson AfterBurner module which generates bytecode for avoiding reflection on fields and methods.

Benchmarks shows a peformance speed up by 13x !


cc @davidrapin @john-bodley 

Link to snapshot : https://www.dropbox.com/s/ddxw0z6cha67a7k/graphaware-neo4j-to-elasticsearch-3.3.3.52.8-SNAPSHOT.jar?dl=0