### PR TITLE
Remove extraneous single-quote from json-mapper doc

### DIFF
--- a/docs/json-mapper.md
+++ b/docs/json-mapper.md
@@ -195,7 +195,7 @@ on the value of a property, you can use the following as example :
 ```json
 {
       "condition": "getLabels().length > 0",
-      "index": "'nodes-' + getProperty('actionType').toLower()'",
+      "index": "'nodes-' + getProperty('actionType').toLower()",
       "type": "action"
 }
 ```


### PR DESCRIPTION
I do not own a printer, so please feel free to make this one character change yourself.