### PR TITLE
Timeout Configs Gets Overwritten

### DIFF
--- a/src/main/java/com/graphaware/module/es/ElasticSearchConfiguration.java
+++ b/src/main/java/com/graphaware/module/es/ElasticSearchConfiguration.java
@@ -164,11 +164,11 @@ public class ElasticSearchConfiguration extends BaseTxDrivenModuleConfiguration<
     public ElasticSearchConfiguration withMapping(Mapping mapping, Map<String, String> mappingConfig) {
         // prevents mappings from being started without configure() from being called
         mapping.configure(mappingConfig);
-        return new ElasticSearchConfiguration(getInclusionPolicies(), initializeUntil(), getProtocol(), getUri(), getPort(), getKeyProperty(), isRetryOnError(), getMaxConsecutiveErrors(), getQueueCapacity(), getReindexBatchSize(), isExecuteBulk(), getAuthUser(), getAuthPassword(), mapping, isAsyncIndexation(), DEFAULT_READ_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT);
+        return new ElasticSearchConfiguration(getInclusionPolicies(), initializeUntil(), getProtocol(), getUri(), getPort(), getKeyProperty(), isRetryOnError(), getMaxConsecutiveErrors(), getQueueCapacity(), getReindexBatchSize(), isExecuteBulk(), getAuthUser(), getAuthPassword(), mapping, isAsyncIndexation(), getReadTimeout(), getConnectionTimeout());
     }
 
     public ElasticSearchConfiguration withAsyncIndexation(boolean asyncIndexation) {
-        return new ElasticSearchConfiguration(getInclusionPolicies(), initializeUntil(), getProtocol(), getUri(), getPort(), getKeyProperty(), isRetryOnError(), getMaxConsecutiveErrors(), getQueueCapacity(), getReindexBatchSize(), isExecuteBulk(), getAuthUser(), getAuthPassword(), getMapping(), asyncIndexation, DEFAULT_READ_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT);
+        return new ElasticSearchConfiguration(getInclusionPolicies(), initializeUntil(), getProtocol(), getUri(), getPort(), getKeyProperty(), isRetryOnError(), getMaxConsecutiveErrors(), getQueueCapacity(), getReindexBatchSize(), isExecuteBulk(), getAuthUser(), getAuthPassword(), getMapping(), asyncIndexation, getReadTimeout(), getConnectionTimeout());
     }
 
     public String getProtocol() {


### PR DESCRIPTION
readTimeout and connectionTimeout are parameters that must be tuned, to accommodate for application based delays in getting information from ElasticSearch. 

Currently, both these parameters get overwritten to their default value in spite of setting them in the neo4j config. 

This happens because when we set mapping using "withMapping" function of ElasticSearchConfiguration, it overwrites those timeout parameters. And within "ElasticSearchModuleBootstrapper", withMapping is always the last thing that is called. Thus those timeout configs will never come into effect. 

This fix is to prevent that. 

